### PR TITLE
Implement basic local auth

### DIFF
--- a/lib/features/auth/controller/auth_controller.dart
+++ b/lib/features/auth/controller/auth_controller.dart
@@ -2,9 +2,19 @@ import 'package:flutter_boilerplate/features/auth/repository/auth_repo.dart';
 
 class AuthController {
   final AuthRepo authRepo;
+
   AuthController({required this.authRepo});
 
-  void login() {
-    String token = authRepo.login();
+  /// Save the login flag/token locally.
+  Future<void> login() async {
+    await authRepo.saveLogin();
   }
+
+  /// Remove the login flag/token.
+  Future<void> logout() async {
+    await authRepo.logout();
+  }
+
+  /// Whether the user is currently logged in.
+  bool get isLoggedIn => authRepo.isLoggedIn();
 }

--- a/lib/features/auth/repository/auth_repo.dart
+++ b/lib/features/auth/repository/auth_repo.dart
@@ -5,12 +5,23 @@ import 'package:shared_preferences/shared_preferences.dart';
 class AuthRepo {
   final ApiClient apiClient;
   final SharedPreferences sharedPreferences;
-  AuthRepo({required this.apiClient})
 
-  String login() {
-    String token = '';
+  AuthRepo({required this.apiClient, required this.sharedPreferences});
+
+  /// Save a dummy token locally to simulate a successful login.
+  Future<void> saveLogin() async {
+    const token = 'dummy_token';
     apiClient.updateHeader(token);
-    sharedPreferences.setString(AppConstants.token, token);
-    return apiClient.getData(AppConstants.loginUri)['abc'];
+    await sharedPreferences.setString(AppConstants.token, token);
+  }
+
+  /// Remove the saved token from [SharedPreferences].
+  Future<void> logout() async {
+    await sharedPreferences.remove(AppConstants.token);
+  }
+
+  /// Whether a token already exists in storage.
+  bool isLoggedIn() {
+    return sharedPreferences.containsKey(AppConstants.token);
   }
 }

--- a/lib/features/auth/sign_in_screen.dart
+++ b/lib/features/auth/sign_in_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_boilerplate/base/custom_button.dart';
 import 'package:flutter_boilerplate/base/custom_text_field.dart';
+import 'package:flutter_boilerplate/features/auth/controller/auth_controller.dart';
+import 'package:flutter_boilerplate/features/home/home_screen.dart';
+import 'package:get/get.dart';
 
 class SignInScreen extends StatefulWidget {
   const SignInScreen({super.key});
@@ -10,16 +13,56 @@ class SignInScreen extends StatefulWidget {
 }
 
 class _SignInScreenState extends State<SignInScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final FocusNode _emailFocus = FocusNode();
+  final FocusNode _passwordFocus = FocusNode();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _emailFocus.dispose();
+    _passwordFocus.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Column(children: [
-
-      CustomTextField(controller: controller, hintText: 'email', focusNode: ),
-
-      CustomTextField(controller: controller, hintText: 'password'),
-
-      CustomButton(buttonText: 'Login'),
-
-    ]);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sign In')),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CustomTextField(
+                controller: _emailController,
+                hintText: 'Email',
+                focusNode: _emailFocus,
+                nextFocus: _passwordFocus,
+              ),
+              const SizedBox(height: 16),
+              CustomTextField(
+                controller: _passwordController,
+                hintText: 'Password',
+                focusNode: _passwordFocus,
+                isPassword: true,
+                inputAction: TextInputAction.done,
+              ),
+              const SizedBox(height: 16),
+              CustomButton(
+                buttonText: 'Login',
+                onPressed: () async {
+                  await Get.find<AuthController>().login();
+                  Get.offAll(const HomeScreen());
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter_boilerplate/controller/localization_controller.dart';
-import 'package:flutter_boilerplate/controller/splash_controller.dart';
 import 'package:flutter_boilerplate/controller/theme_controller.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_boilerplate/features/auth/controller/auth_controller.dart';
+import 'package:flutter_boilerplate/features/auth/sign_in_screen.dart';
 import 'package:flutter_boilerplate/features/splash/splash_screen.dart';
 import 'package:flutter_boilerplate/util/styles.dart';
 import 'package:get/get.dart';
@@ -19,17 +20,24 @@ class HomeScreen extends StatelessWidget {
             onPressed: () => Get.find<ThemeController>().toggleTheme(),
             child: Text('Toggle theme'),
           ),
-          TextButton(
-            onPressed: () {
-              Get.to(SplashScreen());
-              Get.find<LocalizationController>().setLanguage(Locale(
-                Get.locale?.languageCode == 'en' ? 'ar' : 'en',
-                Get.locale?.countryCode == 'US' ? 'SA' : 'US',
-              ));
-            },
-            child: Text('Change Localization'),
-          ),
-        ]),
+        TextButton(
+          onPressed: () {
+            Get.to(SplashScreen());
+            Get.find<LocalizationController>().setLanguage(Locale(
+              Get.locale?.languageCode == 'en' ? 'ar' : 'en',
+              Get.locale?.countryCode == 'US' ? 'SA' : 'US',
+            ));
+          },
+          child: Text('Change Localization'),
+        ),
+        TextButton(
+          onPressed: () async {
+            await Get.find<AuthController>().logout();
+            Get.offAll(const SignInScreen());
+          },
+          child: const Text('Logout'),
+        ),
+      ]),
       ),
     );
   }

--- a/lib/features/splash/splash_screen.dart
+++ b/lib/features/splash/splash_screen.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
-import 'package:flutter_boilerplate/controller/splash_controller.dart';
+import 'package:flutter_boilerplate/features/auth/controller/auth_controller.dart';
 import 'package:flutter_boilerplate/features/auth/sign_in_screen.dart';
-import 'package:flutter_boilerplate/helper/route_helper.dart';
+import 'package:flutter_boilerplate/features/home/home_screen.dart';
 import 'package:flutter_boilerplate/util/images.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -15,29 +15,16 @@ class SplashScreen extends StatefulWidget {
 }
 
 class SplashScreenState extends State<SplashScreen> {
-
   @override
   void initState() {
     super.initState();
 
-    Future.delayed(Duration(seconds: 2), () {
-      if(Get.find<SplashController>().existToken()) {
-        Get.to(Dashbord);
-      }else {
-        Get.to(SignInScreen());
+    Future.delayed(const Duration(seconds: 2), () {
+      if (Get.find<AuthController>().isLoggedIn) {
+        Get.offAll(const HomeScreen());
+      } else {
+        Get.offAll(const SignInScreen());
       }
-    });
-
-    Get.find<SplashController>().initSharedData();
-    _route();
-
-  }
-
-  void _route() {
-    Get.find<SplashController>().getConfigData().then((value) {
-      Timer(Duration(seconds: 1), () async {
-        Get.offNamed(RouteHelper.home);
-      });
     });
   }
 

--- a/lib/helper/get_di.dart
+++ b/lib/helper/get_di.dart
@@ -24,7 +24,7 @@ Future<Map<String, Map<String, String>>> init() async {
   // Repository
   Get.lazyPut(() => SplashRepo(sharedPreferences: Get.find(), apiClient: Get.find()));
   Get.lazyPut(() => LanguageRepo());
-  Get.lazyPut(() => AuthRepo(apiClient: Get.find()));
+  Get.lazyPut(() => AuthRepo(apiClient: Get.find(), sharedPreferences: Get.find()));
 
   // Controller
   Get.lazyPut(() => ThemeController(sharedPreferences: Get.find()));


### PR DESCRIPTION
## Summary
- implement local AuthRepo methods for saving and removing login state
- expose login/logout/isLoggedIn helpers in AuthController
- build a simple SignInScreen
- add logout button on HomeScreen
- check login flag from SharedPreferences in SplashScreen
- wire up AuthRepo dependency in GetX DI
- dispose text controllers in SignInScreen

## Testing
- ❌ `flutter analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68404e357ca4832aa80fcc7b38832e74