### PR TITLE
Implement basic role-based user system

### DIFF
--- a/lib/data/model/transaction/wallet_transaction.dart
+++ b/lib/data/model/transaction/wallet_transaction.dart
@@ -1,0 +1,30 @@
+enum TransactionType { advance, purchase }
+
+class WalletTransaction {
+  final double amount;
+  final TransactionType type;
+  final DateTime date;
+  final String description;
+
+  WalletTransaction({
+    required this.amount,
+    required this.type,
+    required this.date,
+    required this.description,
+  });
+
+  WalletTransaction.fromJson(Map<String, dynamic> json)
+      : amount = json['amount'],
+        type = TransactionType.values.firstWhere(
+            (e) => e.toString() == json['type'],
+            orElse: () => TransactionType.advance),
+        date = DateTime.parse(json['date']),
+        description = json['description'];
+
+  Map<String, dynamic> toJson() => {
+        'amount': amount,
+        'type': type.toString(),
+        'date': date.toIso8601String(),
+        'description': description,
+      };
+}

--- a/lib/data/model/user/role.dart
+++ b/lib/data/model/user/role.dart
@@ -1,0 +1,1 @@
+enum UserRole { owner, assistant }

--- a/lib/data/model/user/user.dart
+++ b/lib/data/model/user/user.dart
@@ -1,0 +1,31 @@
+import '../wallet/wallet.dart';
+import 'role.dart';
+
+class UserModel {
+  final String id;
+  final String name;
+  final UserRole role;
+  final Wallet wallet;
+
+  UserModel({
+    required this.id,
+    required this.name,
+    required this.role,
+    Wallet? wallet,
+  }) : wallet = wallet ?? Wallet();
+
+  UserModel.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        name = json['name'],
+        role = UserRole.values.firstWhere(
+            (e) => e.toString() == json['role'],
+            orElse: () => UserRole.assistant),
+        wallet = Wallet.fromJson(json['wallet']);
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'role': role.toString(),
+        'wallet': wallet.toJson(),
+      };
+}

--- a/lib/data/model/wallet/wallet.dart
+++ b/lib/data/model/wallet/wallet.dart
@@ -1,0 +1,20 @@
+import '../transaction/wallet_transaction.dart';
+
+class Wallet {
+  double balance;
+  final List<WalletTransaction> transactions;
+
+  Wallet({this.balance = 0, List<WalletTransaction>? transactions})
+      : transactions = transactions ?? [];
+
+  Wallet.fromJson(Map<String, dynamic> json)
+      : balance = json['balance'],
+        transactions = (json['transactions'] as List?)
+                ?.map((e) => WalletTransaction.fromJson(e))
+                .toList() ?? [];
+
+  Map<String, dynamic> toJson() => {
+        'balance': balance,
+        'transactions': transactions.map((e) => e.toJson()).toList(),
+      };
+}

--- a/lib/features/auth/controller/auth_controller.dart
+++ b/lib/features/auth/controller/auth_controller.dart
@@ -1,9 +1,22 @@
+import 'dart:convert';
+
 import 'package:flutter_boilerplate/features/auth/repository/auth_repo.dart';
+import 'package:flutter_boilerplate/data/model/user/user.dart';
 
 class AuthController {
   final AuthRepo authRepo;
 
   AuthController({required this.authRepo});
+
+  UserModel? get currentUser {
+    final jsonString = authRepo.getUser();
+    if (jsonString == null) return null;
+    return UserModel.fromJson(jsonDecode(jsonString));
+  }
+
+  Future<void> signUp(UserModel user) async {
+    await authRepo.signUp(jsonEncode(user.toJson()));
+  }
 
   /// Save the login flag/token locally.
   Future<void> login() async {
@@ -17,4 +30,6 @@ class AuthController {
 
   /// Whether the user is currently logged in.
   bool get isLoggedIn => authRepo.isLoggedIn();
+
+  bool get isOwner => currentUser?.role == UserRole.owner;
 }

--- a/lib/features/auth/repository/auth_repo.dart
+++ b/lib/features/auth/repository/auth_repo.dart
@@ -15,9 +15,23 @@ class AuthRepo {
     await sharedPreferences.setString(AppConstants.token, token);
   }
 
+  Future<void> signUp(String userJson) async {
+    await saveLogin();
+    await saveUser(userJson);
+  }
+
+  Future<void> saveUser(String userJson) async {
+    await sharedPreferences.setString(AppConstants.userData, userJson);
+  }
+
+  String? getUser() {
+    return sharedPreferences.getString(AppConstants.userData);
+  }
+
   /// Remove the saved token from [SharedPreferences].
   Future<void> logout() async {
     await sharedPreferences.remove(AppConstants.token);
+    await sharedPreferences.remove(AppConstants.userData);
   }
 
   /// Whether a token already exists in storage.

--- a/lib/features/auth/sign_in_screen.dart
+++ b/lib/features/auth/sign_in_screen.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_boilerplate/base/custom_button.dart';
 import 'package:flutter_boilerplate/base/custom_text_field.dart';
 import 'package:flutter_boilerplate/features/auth/controller/auth_controller.dart';
-import 'package:flutter_boilerplate/features/home/home_screen.dart';
+import 'package:flutter_boilerplate/features/dashboard/assistant_dashboard.dart';
+import 'package:flutter_boilerplate/features/dashboard/owner_dashboard.dart';
+import 'package:flutter_boilerplate/features/auth/signup_screen.dart';
+import 'package:flutter_boilerplate/data/model/user/role.dart';
 import 'package:get/get.dart';
 
 class SignInScreen extends StatefulWidget {
@@ -56,8 +59,19 @@ class _SignInScreenState extends State<SignInScreen> {
                 buttonText: 'Login',
                 onPressed: () async {
                   await Get.find<AuthController>().login();
-                  Get.offAll(const HomeScreen());
+                  final user = Get.find<AuthController>().currentUser;
+                  if (user?.role == UserRole.owner) {
+                    Get.offAll(const OwnerDashboard());
+                  } else {
+                    Get.offAll(const AssistantDashboard());
+                  }
                 },
+              ),
+              TextButton(
+                onPressed: () {
+                  Get.to(const SignUpScreen());
+                },
+                child: const Text('Sign Up'),
               ),
             ],
           ),

--- a/lib/features/auth/signup_screen.dart
+++ b/lib/features/auth/signup_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_boilerplate/base/custom_button.dart';
+import 'package:flutter_boilerplate/base/custom_text_field.dart';
+import 'package:flutter_boilerplate/features/auth/controller/auth_controller.dart';
+import 'package:flutter_boilerplate/data/model/user/role.dart';
+import 'package:flutter_boilerplate/data/model/user/user.dart';
+import 'package:flutter_boilerplate/features/dashboard/assistant_dashboard.dart';
+import 'package:flutter_boilerplate/features/dashboard/owner_dashboard.dart';
+import 'package:get/get.dart';
+
+class SignUpScreen extends StatefulWidget {
+  const SignUpScreen({super.key});
+
+  @override
+  State<SignUpScreen> createState() => _SignUpScreenState();
+}
+
+class _SignUpScreenState extends State<SignUpScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  UserRole _role = UserRole.owner;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sign Up')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            CustomTextField(
+              controller: _nameController,
+              hintText: 'Name',
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Radio<UserRole>(
+                  value: UserRole.owner,
+                  groupValue: _role,
+                  onChanged: (val) => setState(() => _role = val!),
+                ),
+                const Text('Owner'),
+                Radio<UserRole>(
+                  value: UserRole.assistant,
+                  groupValue: _role,
+                  onChanged: (val) => setState(() => _role = val!),
+                ),
+                const Text('Assistant'),
+              ],
+            ),
+            const SizedBox(height: 16),
+            CustomButton(
+              buttonText: 'Create Account',
+              onPressed: () async {
+                final user = UserModel(
+                  id: DateTime.now().microsecondsSinceEpoch.toString(),
+                  name: _nameController.text,
+                  role: _role,
+                );
+                await Get.find<AuthController>().signUp(user);
+                if (_role == UserRole.owner) {
+                  Get.offAll(const OwnerDashboard());
+                } else {
+                  Get.offAll(const AssistantDashboard());
+                }
+              },
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/assistant_dashboard.dart
+++ b/lib/features/dashboard/assistant_dashboard.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class AssistantDashboard extends StatelessWidget {
+  const AssistantDashboard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Assistant Dashboard')),
+      body: const Center(child: Text('Assistant tasks here')),
+    );
+  }
+}

--- a/lib/features/dashboard/owner_dashboard.dart
+++ b/lib/features/dashboard/owner_dashboard.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_boilerplate/util/role_guard.dart';
+import 'package:get/get.dart';
+
+class OwnerDashboard extends StatelessWidget {
+  const OwnerDashboard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Owner Dashboard')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            if (RoleGuard.ensureOwner()) {
+              Get.snackbar('Action', 'Assign order logic here');
+            }
+          },
+          child: const Text('Assign Order'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/splash/splash_screen.dart
+++ b/lib/features/splash/splash_screen.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:flutter_boilerplate/features/auth/controller/auth_controller.dart';
 import 'package:flutter_boilerplate/features/auth/sign_in_screen.dart';
-import 'package:flutter_boilerplate/features/home/home_screen.dart';
+import 'package:flutter_boilerplate/features/dashboard/assistant_dashboard.dart';
+import 'package:flutter_boilerplate/features/dashboard/owner_dashboard.dart';
+import 'package:flutter_boilerplate/data/model/user/role.dart';
 import 'package:flutter_boilerplate/util/images.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -20,8 +22,14 @@ class SplashScreenState extends State<SplashScreen> {
     super.initState();
 
     Future.delayed(const Duration(seconds: 2), () {
-      if (Get.find<AuthController>().isLoggedIn) {
-        Get.offAll(const HomeScreen());
+      final auth = Get.find<AuthController>();
+      if (auth.isLoggedIn) {
+        final user = auth.currentUser;
+        if (user?.role == UserRole.owner) {
+          Get.offAll(const OwnerDashboard());
+        } else {
+          Get.offAll(const AssistantDashboard());
+        }
       } else {
         Get.offAll(const SignInScreen());
       }

--- a/lib/helper/route_helper.dart
+++ b/lib/helper/route_helper.dart
@@ -1,4 +1,6 @@
-import 'package:flutter_boilerplate/features/home/home_screen.dart';
+import 'package:flutter_boilerplate/features/dashboard/assistant_dashboard.dart';
+import 'package:flutter_boilerplate/features/dashboard/owner_dashboard.dart';
+import 'package:flutter_boilerplate/features/auth/signup_screen.dart';
 import 'package:flutter_boilerplate/features/splash/splash_screen.dart';
 import 'package:get/get.dart';
 
@@ -6,6 +8,9 @@ class RouteHelper {
   static const String initial = '/';
   static const String splash = '/splash';
   static const String home = '/home';
+  static const String signUp = '/signup';
+  static const String ownerDashboard = '/owner';
+  static const String assistantDashboard = '/assistant';
 
   static getInitialRoute() => initial;
   static getSplashRoute() => splash;
@@ -14,6 +19,8 @@ class RouteHelper {
   static List<GetPage> routes = [
     GetPage(name: initial, page: () => SplashScreen()),
     GetPage(name: splash, page: () => SplashScreen()),
-    GetPage(name: home, page: () => HomeScreen()),
+    GetPage(name: signUp, page: () => const SignUpScreen()),
+    GetPage(name: ownerDashboard, page: () => const OwnerDashboard()),
+    GetPage(name: assistantDashboard, page: () => const AssistantDashboard()),
   ];
 }

--- a/lib/util/app_constants.dart
+++ b/lib/util/app_constants.dart
@@ -19,6 +19,7 @@ class AppConstants {
   static const String userNumber = 'user_number';
   static const String searchAddress = 'search_address';
   static const String topic = 'notify';
+  static const String userData = 'user_data';
 
   static List<LanguageModel> languages = [
     LanguageModel(imageUrl: Images.unitedKingdom, languageName: 'English', countryCode: 'US', languageCode: 'en'),

--- a/lib/util/role_guard.dart
+++ b/lib/util/role_guard.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_boilerplate/features/auth/controller/auth_controller.dart';
+import 'package:get/get.dart';
+
+class RoleGuard {
+  static bool ensureOwner() {
+    final auth = Get.find<AuthController>();
+    if (!auth.isOwner) {
+      Get.snackbar('Access Denied', 'Only owners can perform this action');
+      return false;
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- define role, user, wallet and transaction models
- persist user data in `AuthRepo` and expose through `AuthController`
- implement signup with role choice and dashboards per role
- guard owner-only actions and route from splash/login accordingly

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840537c3f24832a89b64f2ce8f8898c