### PR TITLE
Fix dashboard widgets and imports

### DIFF
--- a/lib/features/auth/controller/auth_controller.dart
+++ b/lib/features/auth/controller/auth_controller.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_boilerplate/features/auth/repository/auth_repo.dart';
 import 'package:flutter_boilerplate/data/model/user/user.dart';
+import 'package:flutter_boilerplate/data/model/user/role.dart';
 import 'package:get/get.dart';
 
 class AuthController extends GetxController {

--- a/lib/features/auth/widget/login_card.dart
+++ b/lib/features/auth/widget/login_card.dart
@@ -1,13 +1,16 @@
-class LoginCard extends StatefulWidget {
-  const LoginCard({super.key});
+import 'package:flutter/material.dart';
+import '../../../base/custom_text_field.dart';
 
-  @override
-  State<LoginCard> createState() => _LoginCardState();
-}
+class LoginCard extends StatelessWidget {
+  final TextEditingController controller;
+  const LoginCard({super.key, required this.controller});
 
-class _LoginCardState extends State<LoginCard> {
   @override
   Widget build(BuildContext context) {
-    return CustomTextField(controller: controller, hintText: 'email');
+    return CustomTextField(
+      controller: controller,
+      hintText: 'Email',
+      inputType: TextInputType.emailAddress,
+    );
   }
 }

--- a/lib/features/dashboard/assistant_dashboard.dart
+++ b/lib/features/dashboard/assistant_dashboard.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:flutter_boilerplate/features/auth/controller/auth_controller.dart';
 import 'package:flutter_boilerplate/helper/route_helper.dart';
-import 'package:get/get.dart';
-
 
 class AssistantDashboard extends StatelessWidget {
   const AssistantDashboard({super.key});
@@ -15,18 +13,19 @@ class AssistantDashboard extends StatelessWidget {
       return Scaffold(
         appBar: AppBar(title: Text('assistant_dashboard'.tr)),
         body: Center(
-          child: Text('wallet_balance'.tr + ': \$${balance.toStringAsFixed(2)}'),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('wallet_balance'.tr + ': \$${balance.toStringAsFixed(2)}'),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Get.toNamed(RouteHelper.getOrdersRoute()),
+                child: const Text('View Orders'),
+              ),
+            ],
+          ),
         ),
       );
     });
-    return Scaffold(
-      appBar: AppBar(title: const Text('Assistant Dashboard')),
-      body: Center(
-        child: ElevatedButton(
-          onPressed: () => Get.toNamed(RouteHelper.getOrdersRoute()),
-          child: const Text('View Orders'),
-        ),
-      ),
-    );
   }
 }

--- a/lib/features/dashboard/owner_dashboard.dart
+++ b/lib/features/dashboard/owner_dashboard.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_boilerplate/util/role_guard.dart';
 import 'package:flutter_boilerplate/helper/route_helper.dart';
 import 'package:get/get.dart';
-import 'package:flutter_boilerplate/helper/route_helper.dart';
 
 class OwnerDashboard extends StatelessWidget {
   const OwnerDashboard({super.key});
@@ -31,6 +30,9 @@ class OwnerDashboard extends StatelessWidget {
                 }
               },
               child: Text('record_advance'.tr),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
               onPressed: () => Get.toNamed(RouteHelper.getOrdersRoute()),
               child: const Text('View Orders'),
             ),


### PR DESCRIPTION
## Summary
- fix imports for `AuthController`
- clean up `LoginCard` widget
- remove duplicate imports and unreachable code in `AssistantDashboard`
- fix owner dashboard buttons
- add placeholder image folder

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_b_68405bbc7eb0832a8a190925d6257d9e