### PR TITLE
Fix controllers to implement GetxService

### DIFF
--- a/lib/features/auth/controller/auth_controller.dart
+++ b/lib/features/auth/controller/auth_controller.dart
@@ -5,7 +5,7 @@ import 'package:flutter_boilerplate/data/model/user/user.dart';
 import 'package:flutter_boilerplate/data/model/user/role.dart';
 import 'package:get/get.dart';
 
-class AuthController extends GetxController {
+class AuthController extends GetxController implements GetxService {
   final AuthRepo authRepo;
   AuthController({required this.authRepo}) {
     loadUser();

--- a/lib/features/finance/controller/advance_controller.dart
+++ b/lib/features/finance/controller/advance_controller.dart
@@ -6,7 +6,7 @@ import 'package:get/get.dart';
 import 'package:flutter_boilerplate/data/model/history/history_log.dart';
 import 'package:flutter_boilerplate/features/history/controller/history_controller.dart';
 
-class AdvanceController extends GetxController {
+class AdvanceController extends GetxController implements GetxService {
   final AdvanceRepo advanceRepo;
   AdvanceController({required this.advanceRepo});
 

--- a/lib/features/history/controller/history_controller.dart
+++ b/lib/features/history/controller/history_controller.dart
@@ -2,7 +2,7 @@ import 'package:flutter_boilerplate/data/model/history/history_log.dart';
 import 'package:flutter_boilerplate/features/history/repository/history_repo.dart';
 import 'package:get/get.dart';
 
-class HistoryController extends GetxController {
+class HistoryController extends GetxController implements GetxService {
   final HistoryRepo historyRepo;
   HistoryController({required this.historyRepo});
 

--- a/lib/features/orders/controller/order_controller.dart
+++ b/lib/features/orders/controller/order_controller.dart
@@ -6,7 +6,7 @@ import 'package:flutter_boilerplate/data/model/order/order.dart';
 import 'package:flutter_boilerplate/data/model/order/order_status.dart';
 import 'package:flutter_boilerplate/features/auth/controller/auth_controller.dart';
 
-class OrderController extends GetxController {
+class OrderController extends GetxController implements GetxService {
   final OrderRepo orderRepo;
   OrderController({required this.orderRepo});
 


### PR DESCRIPTION
## Summary
- revert controllers to use `GetxController` while implementing `GetxService`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68432a0e8f80832aaa07190157847c00