### PR TITLE
Align models with API and modernize UI theme

### DIFF
--- a/lib/data/model/order/order.dart
+++ b/lib/data/model/order/order.dart
@@ -12,30 +12,31 @@ class Order {
     required this.orderId,
     required this.createdBy,
     this.assignedTo,
-    this.status = OrderStatus.draft,
+    this.status = OrderStatus.pending,
     required this.createdAt,
     this.completedAt,
   });
 
   Order.fromJson(Map<String, dynamic> json)
-      : orderId = json['orderId'],
-        createdBy = json['createdBy'],
-        assignedTo = json['assignedTo'],
-        status = OrderStatus.values.firstWhere(
-          (e) => e.toString() == json['status'],
-          orElse: () => OrderStatus.draft,
-        ),
-        createdAt = DateTime.parse(json['createdAt']),
+      : orderId = (json['orderId'] ?? json['id']).toString(),
+        createdBy = (json['createdBy'] ?? json['created_by']).toString(),
+        assignedTo = json['assignedTo']?.toString() ??
+            json['assigned_to']?.toString(),
+        status = OrderStatusExtension.fromString(json['status'] ?? 'pending'),
+        createdAt = DateTime.parse(
+            json['createdAt'] ?? json['created_at']),
         completedAt = json['completedAt'] != null
             ? DateTime.parse(json['completedAt'])
-            : null;
+            : json['completed_at'] != null
+                ? DateTime.parse(json['completed_at'])
+                : null;
 
   Map<String, dynamic> toJson() => {
-        'orderId': orderId,
-        'createdBy': createdBy,
-        'assignedTo': assignedTo,
-        'status': status.toString(),
-        'createdAt': createdAt.toIso8601String(),
-        'completedAt': completedAt?.toIso8601String(),
+        'id': orderId,
+        'created_by': createdBy,
+        'assigned_to': assignedTo,
+        'status': status.toApi(),
+        'created_at': createdAt.toIso8601String(),
+        'completed_at': completedAt?.toIso8601String(),
       };
 }

--- a/lib/data/model/order/order_status.dart
+++ b/lib/data/model/order/order_status.dart
@@ -1,1 +1,25 @@
-enum OrderStatus { draft, assigned, inProgress, completed }
+enum OrderStatus { pending, inProgress, completed }
+
+extension OrderStatusExtension on OrderStatus {
+  static OrderStatus fromString(String value) {
+    switch (value.toLowerCase()) {
+      case 'in_progress':
+        return OrderStatus.inProgress;
+      case 'completed':
+        return OrderStatus.completed;
+      default:
+        return OrderStatus.pending;
+    }
+  }
+
+  String toApi() {
+    switch (this) {
+      case OrderStatus.inProgress:
+        return 'in_progress';
+      case OrderStatus.completed:
+        return 'completed';
+      default:
+        return 'pending';
+    }
+  }
+}

--- a/lib/data/model/user/role.dart
+++ b/lib/data/model/user/role.dart
@@ -1,1 +1,11 @@
 enum UserRole { owner, assistant }
+
+extension UserRoleExtension on UserRole {
+  static UserRole fromString(String value) {
+    return value.toLowerCase() == 'owner' ? UserRole.owner : UserRole.assistant;
+  }
+
+  String toApi() {
+    return this == UserRole.owner ? 'owner' : 'assistant';
+  }
+}

--- a/lib/data/model/user/user.dart
+++ b/lib/data/model/user/user.dart
@@ -15,17 +15,17 @@ class UserModel {
   }) : wallet = wallet ?? Wallet();
 
   UserModel.fromJson(Map<String, dynamic> json)
-      : id = json['id'],
+      : id = json['id'].toString(),
         name = json['name'],
-        role = UserRole.values.firstWhere(
-            (e) => e.toString() == json['role'],
-            orElse: () => UserRole.assistant),
-        wallet = Wallet.fromJson(json['wallet']);
+        role = UserRoleExtension.fromString(json['role'] ?? 'assistant'),
+        wallet = json['wallet'] != null
+            ? Wallet.fromJson(json['wallet'])
+            : Wallet();
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,
-        'role': role.toString(),
+        'role': role.toApi(),
         'wallet': wallet.toJson(),
       };
 }

--- a/lib/features/orders/controller/order_controller.dart
+++ b/lib/features/orders/controller/order_controller.dart
@@ -10,7 +10,7 @@ class OrderController extends GetxController implements GetxService {
   final OrderRepo orderRepo;
   OrderController({required this.orderRepo});
 
-  List<Order> getOrders({OrderStatus? status, String? assignedTo}) {
+  Future<List<Order>> getOrders({OrderStatus? status, String? assignedTo}) {
     return orderRepo.getOrders(status: status, assignedTo: assignedTo);
   }
 

--- a/lib/features/orders/order_list_screen.dart
+++ b/lib/features/orders/order_list_screen.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:flutter_boilerplate/features/orders/controller/order_controller.dart';
 import 'package:flutter_boilerplate/helper/route_helper.dart';
 import 'package:flutter_boilerplate/data/model/order/order_status.dart';
+import 'package:flutter_boilerplate/data/model/order/order.dart';
 
 class OrderListScreen extends StatelessWidget {
   final OrderStatus? status;
@@ -12,24 +13,29 @@ class OrderListScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GetBuilder<OrderController>(builder: (controller) {
-      final orders = controller.getOrders(status: status, assignedTo: assignedTo);
-      return Scaffold(
-        appBar: AppBar(title: Text('orders'.tr)),
-        floatingActionButton: FloatingActionButton(
-          onPressed: controller.createOrder,
-          child: const Icon(Icons.add),
-        ),
-        body: ListView.builder(
-          itemCount: orders.length,
-          itemBuilder: (_, index) {
-            final order = orders[index];
-            return ListTile(
-              title: Text(order.orderId),
-              subtitle: Text(order.status.toString()),
-              onTap: () => Get.toNamed(RouteHelper.getOrderDetailRoute(order.orderId)),
-            );
-          },
-        ),
+      return FutureBuilder<List<Order>>(
+        future: controller.getOrders(status: status, assignedTo: assignedTo),
+        builder: (context, snapshot) {
+          final orders = snapshot.data ?? [];
+          return Scaffold(
+            appBar: AppBar(title: Text('orders'.tr)),
+            floatingActionButton: FloatingActionButton(
+              onPressed: controller.createOrder,
+              child: const Icon(Icons.add),
+            ),
+            body: ListView.builder(
+              itemCount: orders.length,
+              itemBuilder: (_, index) {
+                final order = orders[index];
+                return ListTile(
+                  title: Text(order.orderId),
+                  subtitle: Text(order.status.toString()),
+                  onTap: () => Get.toNamed(RouteHelper.getOrderDetailRoute(order.orderId)),
+                );
+              },
+            ),
+          );
+        },
       );
     });
   }

--- a/lib/features/orders/repository/order_repo.dart
+++ b/lib/features/orders/repository/order_repo.dart
@@ -48,7 +48,7 @@ class OrderRepo {
     final order = getById(orderId);
     if (order != null) {
       order.assignedTo = userId;
-      order.status = OrderStatus.assigned;
+      order.status = OrderStatus.pending;
     }
   }
 

--- a/lib/theme/dark_theme.dart
+++ b/lib/theme/dark_theme.dart
@@ -10,4 +10,6 @@ ThemeData dark = ThemeData(
   cardColor: Colors.black,
   colorScheme: ColorScheme.dark(primary: Color(0xFFcda335), secondary: Color(0xFFcda335), surface: Color(0xFF343636), error: Color(0xFFdd3135)),
   textButtonTheme: TextButtonThemeData(style: TextButton.styleFrom(foregroundColor: Color(0xFFcda335))),
+  useMaterial3: true,
+  visualDensity: VisualDensity.adaptivePlatformDensity,
 );

--- a/lib/theme/light_theme.dart
+++ b/lib/theme/light_theme.dart
@@ -10,4 +10,6 @@ ThemeData light = ThemeData(
   cardColor: Colors.white,
   colorScheme: ColorScheme.light(primary: Color(0xFFdcb247), secondary: Color(0xFFdcb247), surface: Color(0xFFF3F3F3), error: Color(0xFFE84D4F)),
   textButtonTheme: TextButtonThemeData(style: TextButton.styleFrom(foregroundColor: Color(0xFFdcb247))),
+  useMaterial3: true,
+  visualDensity: VisualDensity.adaptivePlatformDensity,
 );


### PR DESCRIPTION
## Summary
- map user role strings to enum via `UserRoleExtension`
- parse API fields for `UserModel` and `Order`
- update order statuses to `pending`, `inProgress`, and `completed`
- fix `OrderController.getOrders` return type and use `FutureBuilder` in `OrderListScreen`
- set Material 3 options in dark and light themes
- adjust order assignment status

## Testing
- `flutter analyze lib`
- `flutter test` *(fails: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_b_68484255a914832a971408618c8bf9da