### PR TITLE
Update endpoints with baseUrl and clean constants

### DIFF
--- a/lib/data/api/api_client.dart
+++ b/lib/data/api/api_client.dart
@@ -14,7 +14,6 @@ import 'package:flutter/foundation.dart' as foundation;
 import 'package:http/http.dart' as http;
 
 class ApiClient extends GetxService {
-  final String appBaseUrl;
   final SharedPreferences sharedPreferences;
   static final String noInternetMessage = 'Connection to API server failed due to internet connection';
   final int timeoutInSeconds = 30;
@@ -22,13 +21,17 @@ class ApiClient extends GetxService {
   late String token;
   late Map<String, String> _mainHeaders;
 
-  ApiClient({required this.appBaseUrl, required this.sharedPreferences}) {
+  ApiClient({required this.sharedPreferences}) {
     token = sharedPreferences.getString(AppConstants.token) ?? '';
     debugPrint('Token: $token');
     _mainHeaders = {
       'Content-Type': 'application/json; charset=UTF-8',
       'Authorization': 'Bearer $token'
     };
+  }
+
+  Uri _getUri(String uri) {
+    return uri.startsWith('http') ? Uri.parse(uri) : Uri.parse(AppConstants.baseUrl + uri);
   }
 
   void updateHeader(String token) {
@@ -42,7 +45,7 @@ class ApiClient extends GetxService {
     try {
       debugPrint('====> API Call: $uri\nToken: $token');
       http.Response response0 = await http.get(
-        Uri.parse(appBaseUrl+uri),
+        _getUri(uri),
         headers: headers ?? _mainHeaders,
       ).timeout(Duration(seconds: timeoutInSeconds));
       Response response = handleResponse(response0);
@@ -58,7 +61,7 @@ class ApiClient extends GetxService {
       debugPrint('====> API Call: $uri\nToken: $token');
       debugPrint('====> API Body: $body');
       http.Response response0 = await http.post(
-        Uri.parse(appBaseUrl+uri),
+        _getUri(uri),
         body: jsonEncode(body),
         headers: headers ?? _mainHeaders,
       ).timeout(Duration(seconds: timeoutInSeconds));
@@ -74,7 +77,7 @@ class ApiClient extends GetxService {
     try {
       debugPrint('====> API Call: $uri\nToken: $token');
       debugPrint('====> API Body: $body');
-      http.MultipartRequest request = http.MultipartRequest('POST', Uri.parse(appBaseUrl+uri));
+      http.MultipartRequest request = http.MultipartRequest('POST', _getUri(uri));
       request.headers.addAll(headers ?? _mainHeaders);
       for(MultipartBody multipart in multipartBody) {
         if(multipart.file != null) {
@@ -108,7 +111,7 @@ class ApiClient extends GetxService {
       debugPrint('====> API Call: $uri\nToken: $token');
       debugPrint('====> API Body: $body');
       http.Response response0 = await http.put(
-        Uri.parse(appBaseUrl+uri),
+        _getUri(uri),
         body: jsonEncode(body),
         headers: headers ?? _mainHeaders,
       ).timeout(Duration(seconds: timeoutInSeconds));
@@ -124,7 +127,7 @@ class ApiClient extends GetxService {
     try {
       debugPrint('====> API Call: $uri\nToken: $token');
       http.Response response0 = await http.delete(
-        Uri.parse(appBaseUrl+uri),
+        _getUri(uri),
         headers: headers ?? _mainHeaders,
       ).timeout(Duration(seconds: timeoutInSeconds));
       Response response = handleResponse(response0);

--- a/lib/data/api/endpoints.dart
+++ b/lib/data/api/endpoints.dart
@@ -1,26 +1,28 @@
+import 'package:flutter_boilerplate/util/app_constants.dart';
+
 class Endpoints {
-  static const login = '/api/auth/login';
-  static const logout = '/api/auth/logout';
-  static const me = '/api/auth/me';
-  static const refresh = '/api/auth/refresh';
+  static const login = '${AppConstants.baseUrl}/api/auth/login';
+  static const logout = '${AppConstants.baseUrl}/api/auth/logout';
+  static const me = '${AppConstants.baseUrl}/api/auth/me';
+  static const refresh = '${AppConstants.baseUrl}/api/auth/refresh';
 
-  static const orders = '/api/orders';
-  static String order(int id) => '/api/orders/\$id';
-  static String assignOrder(int id) => '/api/orders/\$id/assign';
-  static String completeOrder(int id) => '/api/orders/\$id/complete';
+  static const orders = '${AppConstants.baseUrl}/api/orders';
+  static String order(int id) => '${AppConstants.baseUrl}/api/orders/\$id';
+  static String assignOrder(int id) => '${AppConstants.baseUrl}/api/orders/\$id/assign';
+  static String completeOrder(int id) => '${AppConstants.baseUrl}/api/orders/\$id/complete';
 
-  static const orderItems = '/api/order_items';
-  static String itemsOfOrder(int orderId) => '/api/order_items/\$orderId';
-  static String orderItem(int orderId, int id) => '/api/order_items/\$orderId/\$id';
+  static const orderItems = '${AppConstants.baseUrl}/api/order_items';
+  static String itemsOfOrder(int orderId) => '${AppConstants.baseUrl}/api/order_items/\$orderId';
+  static String orderItem(int orderId, int id) => '${AppConstants.baseUrl}/api/order_items/\$orderId/\$id';
 
-  static const payments = '/api/payments';
+  static const payments = '${AppConstants.baseUrl}/api/payments';
 
-  static String wallet(int userId) => '/api/wallet/\$userId';
-  static String walletTransactions(int userId) => '/api/wallet/\$userId/transactions';
+  static String wallet(int userId) => '${AppConstants.baseUrl}/api/wallet/\$userId';
+  static String walletTransactions(int userId) => '${AppConstants.baseUrl}/api/wallet/\$userId/transactions';
 
-  static const history = '/api/history';
-  static String historyByEntity(String entity, int id) => '/api/history/\$entity/\$id';
+  static const history = '${AppConstants.baseUrl}/api/history';
+  static String historyByEntity(String entity, int id) => '${AppConstants.baseUrl}/api/history/\$entity/\$id';
 
-  static const analyticsDashboard = '/api/analytics/dashboard';
-  static const analyticsReports = '/api/analytics/reports';
+  static const analyticsDashboard = '${AppConstants.baseUrl}/api/analytics/dashboard';
+  static const analyticsReports = '${AppConstants.baseUrl}/api/analytics/reports';
 }

--- a/lib/data/repository/splash_repo.dart
+++ b/lib/data/repository/splash_repo.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_boilerplate/data/api/api_client.dart';
+import 'package:flutter_boilerplate/data/api/endpoints.dart';
 import 'package:flutter_boilerplate/util/app_constants.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -9,7 +10,7 @@ class SplashRepo {
   SplashRepo({required this.sharedPreferences, required this.apiClient});
 
   Future<Response> getConfigData() async {
-    Response response = await apiClient.postData(AppConstants.loginUri, {'email': 'ashek@gmail.com', 'password': '0123456'});
+    Response response = await apiClient.postData(Endpoints.login, {'email': 'ashek@gmail.com', 'password': '0123456'});
     return response;
   }
 

--- a/lib/helper/get_di.dart
+++ b/lib/helper/get_di.dart
@@ -29,7 +29,7 @@ Future<Map<String, Map<String, String>>> init() async {
   // Core
   final sharedPreferences = await SharedPreferences.getInstance();
   Get.lazyPut(() => sharedPreferences);
-  Get.lazyPut(() => ApiClient(appBaseUrl: AppConstants.baseUrl, sharedPreferences: Get.find()));
+  Get.lazyPut(() => ApiClient(sharedPreferences: Get.find()));
   Get.lazyPut(() => BazarTrackApi(client: Get.find()));
 
   // Repository

--- a/lib/util/app_constants.dart
+++ b/lib/util/app_constants.dart
@@ -5,8 +5,6 @@ class AppConstants {
   static const String appName = 'Test Product';
 
   static const String baseUrl = 'https://my_base_url';
-  static const String configUri = '/api/v1/config';
-  static const String loginUri = '/api/v1/auth/login';
 
   // Shared Key
   static const String theme = 'theme';


### PR DESCRIPTION
## Summary
- prefix API endpoints with `AppConstants.baseUrl`
- remove unused constants from `AppConstants`
- adjust `SplashRepo` to use the new login endpoint
- update `ApiClient` to handle URLs with or without base URL
- drop `appBaseUrl` dependency from `ApiClient`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848f378900c832ab5f5cc809e41c8b4