### PR TITLE
Fix API date formats

### DIFF
--- a/lib/data/model/advance/advance.dart
+++ b/lib/data/model/advance/advance.dart
@@ -1,3 +1,5 @@
+import '../../../helper/date_converter.dart';
+
 class Advance {
   final double amount;
   final DateTime date;
@@ -13,14 +15,14 @@ class Advance {
 
   factory Advance.fromJson(Map<String, dynamic> json) => Advance(
         amount: json['amount'],
-        date: DateTime.parse(json['date']),
+        date: DateConverter.parseApiDate(json['date']),
         givenBy: json['givenBy'],
         receivedBy: json['receivedBy'],
       );
 
   Map<String, dynamic> toJson() => {
         'amount': amount,
-        'date': date.toIso8601String(),
+        'date': DateConverter.formatApiDate(date),
         'givenBy': givenBy,
         'receivedBy': receivedBy,
       };

--- a/lib/data/model/history/history_log.dart
+++ b/lib/data/model/history/history_log.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_boilerplate/helper/date_converter.dart';
+
 class HistoryLog {
   final String id;
   final String entityType;
@@ -18,22 +20,28 @@ class HistoryLog {
   });
 
   factory HistoryLog.fromJson(Map<String, dynamic> json) => HistoryLog(
-        id: json['id'],
-        entityType: json['entityType'],
-        entityId: json['entityId'],
-        action: json['action'],
-        changedByUserId: json['changedByUserId'],
-        timestamp: DateTime.parse(json['timestamp']),
-        dataSnapshot: Map<String, dynamic>.from(json['dataSnapshot'] ?? {}),
+        id: json['id'].toString(),
+        entityType:
+            json['entityType'] ?? json['entity_type'] ?? '',
+        entityId:
+            (json['entityId'] ?? json['entity_id'] ?? '').toString(),
+        action: json['action'] ?? '',
+        changedByUserId: (json['changedByUserId'] ??
+                json['changed_by_user_id'] ??
+                '')
+            .toString(),
+        timestamp: DateConverter.parseApiDate(json['timestamp']),
+        dataSnapshot: Map<String, dynamic>.from(
+            json['dataSnapshot'] ?? json['data_snapshot'] ?? {}),
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'entityType': entityType,
-        'entityId': entityId,
+        'entity_type': entityType,
+        'entity_id': entityId,
         'action': action,
-        'changedByUserId': changedByUserId,
-        'timestamp': timestamp.toIso8601String(),
-        'dataSnapshot': dataSnapshot,
+        'changed_by_user_id': changedByUserId,
+        'timestamp': DateConverter.formatApiDate(timestamp),
+        'data_snapshot': dataSnapshot,
       };
 }

--- a/lib/data/model/order/order.dart
+++ b/lib/data/model/order/order.dart
@@ -1,4 +1,5 @@
 import 'order_status.dart';
+import '../../../helper/date_converter.dart';
 
 class Order {
   final String orderId;
@@ -23,12 +24,12 @@ class Order {
         assignedTo = json['assignedTo']?.toString() ??
             json['assigned_to']?.toString(),
         status = OrderStatusExtension.fromString(json['status'] ?? 'pending'),
-        createdAt = DateTime.parse(
+        createdAt = DateConverter.parseApiDate(
             json['createdAt'] ?? json['created_at']),
         completedAt = json['completedAt'] != null
-            ? DateTime.parse(json['completedAt'])
+            ? DateConverter.parseApiDate(json['completedAt'])
             : json['completed_at'] != null
-                ? DateTime.parse(json['completed_at'])
+                ? DateConverter.parseApiDate(json['completed_at'])
                 : null;
 
   Map<String, dynamic> toJson() => {
@@ -36,7 +37,9 @@ class Order {
         'created_by': createdBy,
         'assigned_to': assignedTo,
         'status': status.toApi(),
-        'created_at': createdAt.toIso8601String(),
-        'completed_at': completedAt?.toIso8601String(),
+        'created_at': DateConverter.formatApiDate(createdAt),
+        'completed_at': completedAt != null
+            ? DateConverter.formatApiDate(completedAt!)
+            : null,
       };
 }

--- a/lib/data/model/transaction/wallet_transaction.dart
+++ b/lib/data/model/transaction/wallet_transaction.dart
@@ -1,30 +1,32 @@
-enum TransactionType { advance, purchase }
+enum TransactionType { credit, debit }
+
+import '../../../helper/date_converter.dart';
 
 class WalletTransaction {
   final double amount;
   final TransactionType type;
-  final DateTime date;
+  final DateTime createdAt;
   final String description;
 
   WalletTransaction({
     required this.amount,
     required this.type,
-    required this.date,
+    required this.createdAt,
     required this.description,
   });
 
   WalletTransaction.fromJson(Map<String, dynamic> json)
-      : amount = json['amount'],
-        type = TransactionType.values.firstWhere(
-            (e) => e.toString() == json['type'],
-            orElse: () => TransactionType.advance),
-        date = DateTime.parse(json['date']),
-        description = json['description'];
+      : amount = (json['amount'] as num).toDouble(),
+        type = json['type'] == 'debit' ? TransactionType.debit : TransactionType.credit,
+        createdAt = json['created_at'] != null
+            ? DateConverter.parseApiDate(json['created_at'])
+            : DateConverter.parseApiDate(json['date']),
+        description = json['description'] ?? '';
 
   Map<String, dynamic> toJson() => {
         'amount': amount,
-        'type': type.toString(),
-        'date': date.toIso8601String(),
+        'type': type == TransactionType.debit ? 'debit' : 'credit',
+        'created_at': DateConverter.formatApiDate(createdAt),
         'description': description,
       };
 }

--- a/lib/features/finance/controller/advance_controller.dart
+++ b/lib/features/finance/controller/advance_controller.dart
@@ -29,8 +29,8 @@ class AdvanceController extends GetxController implements GetxService {
       user.wallet.balance += advance.amount;
       user.wallet.transactions.add(WalletTransaction(
         amount: advance.amount,
-        type: TransactionType.advance,
-        date: advance.date,
+        type: TransactionType.credit,
+        createdAt: advance.date,
         description: 'Advance from ${advance.givenBy}',
       ));
       await auth.saveUser(user);
@@ -58,8 +58,8 @@ class AdvanceController extends GetxController implements GetxService {
       user.wallet.balance -= amount;
       user.wallet.transactions.add(WalletTransaction(
         amount: amount,
-        type: TransactionType.purchase,
-        date: DateTime.now(),
+        type: TransactionType.debit,
+        createdAt: DateTime.now(),
         description: description,
       ));
       await auth.saveUser(user);

--- a/lib/helper/date_converter.dart
+++ b/lib/helper/date_converter.dart
@@ -1,8 +1,21 @@
 import 'package:intl/intl.dart';
 
 class DateConverter {
+  static String formatApiDate(DateTime dateTime) {
+    return DateFormat('yyyy-MM-dd HH:mm:ss').format(dateTime);
+  }
+
+  static DateTime parseApiDate(String dateTime) {
+    try {
+      return DateFormat('yyyy-MM-dd HH:mm:ss').parse(dateTime, true).toLocal();
+    } catch (_) {
+      return DateTime.parse(dateTime);
+    }
+  }
+
+  @deprecated
   static String formatDate(DateTime dateTime) {
-    return DateFormat('yyyy-MM-dd hh:mm:ss').format(dateTime);
+    return formatApiDate(dateTime);
   }
 
   static String estimatedDate(DateTime dateTime) {


### PR DESCRIPTION
## Summary
- unify date parsing via `DateConverter`
- parse history log timestamps using API format
- parse order timestamps using API format
- parse advance and wallet transaction dates using API format
- handle wallet credit/debit actions in controller

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685892d512cc832aab665708f0f0caf0